### PR TITLE
Feature/allow commit hash

### DIFF
--- a/.github/workflows/k8s_deploy.yml
+++ b/.github/workflows/k8s_deploy.yml
@@ -33,6 +33,11 @@ on:
                 default: true
                 type: boolean
                 description: set to false to disable creating a configmap
+            tag_add_commithash:
+                required: false
+                default: false
+                type: boolean
+                description: Add the current commit hash to the branch (necessary when deploying from a branch)
             cluster:
                 default: 'ub-kub-dev'
                 type: string
@@ -66,6 +71,14 @@ jobs:
             -   uses: actions/checkout@v2
                 with:
                     ref: ${{ inputs.ref_name }}
+
+            -   name: Set TAG_NAME with commit hash
+                if: ${{ inputs.tag_add_commithash }}
+                run: echo "TAG_NAME=${{ inputs.ref_name }}-${GITHUB_SHA::8}" >> $GITHUB_ENV
+
+            -   name: Set TAG_NAME
+                if: ${{ ! inputs.tag_add_commithash }}
+                run: echo "TAG_NAME=${{ inputs.ref_name }}" >> $GITHUB_ENV
 
             -   name: Set AKS context
                 uses: azure/aks-set-context@v1
@@ -105,7 +118,7 @@ jobs:
                     manifests: |
                         ${{ inputs.app_directory }}/manifests/${{ inputs.target }}/deployment.yaml
                     images: |
-                        ${{ secrets.acr_registry }}/${{ inputs.app_name }}${{ inputs.image_name_postfix }}:${{ inputs.ref_name }}
+                        ${{ secrets.acr_registry }}/${{ inputs.app_name }}${{ inputs.image_name_postfix }}:${{ env.TAG_NAME }}
                     imagepullsecrets: |
                         ${{ inputs.pull_secret_name }}
                     namespace: ${{ inputs.namespace }}

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -22,6 +22,11 @@ on:
                 type: string
                 required: false
                 description: comma-separated container volumes for jib-maven-plugin (default /config/)
+            tag_add_commithash:
+                required: false
+                default: false
+                type: boolean
+                description: Add the current commit hash to the branch (necessary when deploying from a branch)
 
         secrets:
             artifactory_user:
@@ -47,42 +52,65 @@ jobs:
                 uses: actions/checkout@v2
                 with:
                     ref: ${{ inputs.ref_name }}
+
             -   name: Git Status
                 run: git status
+
             -   name: Set up JDK
                 uses: actions/setup-java@v2
                 with:
                     java-version: ${{ inputs.java_version }}
                     distribution: 'adopt'
+
             -   name: Cache Maven packages
                 uses: actions/cache@v2
                 with:
                     path: ~/.m2/repository
                     key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
                     restore-keys: ${{ runner.os }}-m2
+
             -   name: Create settings.xml
                 uses: whelk-io/maven-settings-xml-action@8a613be18185c8521e1501081adad5041840f2c8
                 with:
                     servers: '[{"id": "ubique-artifactory", "username": "${{ secrets.artifactory_user}}", "password": "${{ secrets.artifactory_password }}"}]'
                     repositories: '[{"id" : "ubique-artifactory", "url" : "${{ secrets.artifactory_url }}${{ secrets.artifactory_repo }}"}]'
-            -   name: Get version
+
+            -   name: Set TAG_NAME with commit hash
+                if: ${{ inputs.tag_add_commithash }}
+                run: echo "TAG_NAME=${{ inputs.ref_name }}${GITHUB_SHA::8}" >> $GITHUB_ENV
+
+            -   name: Set TAG_NAME
+                if: ${{ ! inputs.tag_add_commithash }}
+                run: echo "TAG_NAME=${{ inputs.ref_name }}" >> $GITHUB_ENV
+
+            -   name: Get version from TAG_NAME with commit hash
+                if: ${{ inputs.tag_add_commithash }}
+                env:
+                    REF_NAME: ${{ inputs.ref_name }}
+                run: echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
+
+            -   name: Get version from tag
+                if: ${{ ! inputs.tag_add_commithash }}
                 env:
                     REF_NAME: ${{ inputs.ref_name }}
                 run: echo "VERSION=${REF_NAME/[v\/]/}" >> $GITHUB_ENV
+
             -   name: Set versions
                 run: mvn -f ${{ inputs.app_directory }}/../pom.xml versions:set -DnewVersion=$VERSION
+
             -   name: Commit versions
                 run: mvn -f ${{ inputs.app_directory }}/../pom.xml versions:commit
+
             -   name: Build with Maven
                 run: mvn --batch-mode --update-snapshots install -DskipTests -f ${{ inputs.app_directory }}/../pom.xml
+
             -   name: Build and push docker
                 run: |
                     mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:3.1.4:build \
                     -f ${{ inputs.app_directory }}/pom.xml \
-                    -Dimage=${{ secrets.acr_registry }}/${{ inputs.app_name }}:${{ inputs.ref_name }} \
+                    -Dimage=${{ secrets.acr_registry }}/${{ inputs.app_name }}:${{ env.TAG_NAME }} \
                     -Djib.from.image=eclipse-temurin:${{ inputs.java_version }} \
                     -Djib.to.auth.username=${{ secrets.acr_username }} \
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.jvmFlags=-XX:MinRAMPercentage=60.0,-XX:MaxRAMPercentage=80.0
-

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -77,7 +77,7 @@ jobs:
 
             -   name: Set TAG_NAME with commit hash
                 if: ${{ inputs.tag_add_commithash }}
-                run: echo "TAG_NAME=${{ inputs.ref_name }}${GITHUB_SHA::8}" >> $GITHUB_ENV
+                run: echo "TAG_NAME=${{ inputs.ref_name }}-${GITHUB_SHA::8}" >> $GITHUB_ENV
 
             -   name: Set TAG_NAME
                 if: ${{ ! inputs.tag_add_commithash }}
@@ -85,8 +85,6 @@ jobs:
 
             -   name: Get version from TAG_NAME with commit hash
                 if: ${{ inputs.tag_add_commithash }}
-                env:
-                    REF_NAME: ${{ inputs.ref_name }}
                 run: echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
 
             -   name: Get version from tag

--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -19,6 +19,11 @@ on:
                 required: true
                 type: string
                 description: 'ENV to build. dev|prod. runs "yarn run build-${release_env}"'
+            tag_add_commithash:
+                required: false
+                default: false
+                type: boolean
+                description: Add the current commit hash to the branch (necessary when deploying from a branch)
             app_name:
                 required: true
                 type: string
@@ -77,6 +82,14 @@ jobs:
                     yarn --cwd ${{ inputs.app_directory }} run build-${{ inputs.release_env }}
                     tar -czvf docker/${{ inputs.app_name }}/bin/${{ inputs.app_name }}.tar.gz -C ${{ inputs.app_directory }}/build .
 
+            -   name: Set TAG_NAME with commit hash
+                if: ${{ inputs.tag_add_commithash }}
+                run: echo "TAG_NAME=${{ inputs.ref_name }}${GITHUB_SHA::8}" >> $GITHUB_ENV
+
+            -   name: Set TAG_NAME
+                if: ${{ ! inputs.tag_add_commithash }}
+                run: echo "TAG_NAME=${{ inputs.ref_name }}" >> $GITHUB_ENV
+
             -   uses: azure/docker-login@v1
                 with:
                     login-server: ${{ secrets.acr_registry }}
@@ -84,5 +97,5 @@ jobs:
                     password: ${{ secrets.acr_password }}
 
             -   run: |
-                    docker build -t ${{ secrets.acr_registry }}/${{ inputs.app_name }}-${{ inputs.release_env }}:${{ inputs.ref_name }} docker/${{ inputs.app_name }}
-                    docker image push ${{ secrets.acr_registry }}/${{ inputs.app_name }}-${{ inputs.release_env }}:${{ inputs.ref_name }}
+                    docker build -t ${{ secrets.acr_registry }}/${{ inputs.app_name }}-${{ inputs.release_env }}:${{ env.TAG_NAME }} docker/${{ inputs.app_name }}
+                    docker image push ${{ secrets.acr_registry }}/${{ inputs.app_name }}-${{ inputs.release_env }}:${{ env.TAG_NAME }}

--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -84,7 +84,7 @@ jobs:
 
             -   name: Set TAG_NAME with commit hash
                 if: ${{ inputs.tag_add_commithash }}
-                run: echo "TAG_NAME=${{ inputs.ref_name }}${GITHUB_SHA::8}" >> $GITHUB_ENV
+                run: echo "TAG_NAME=${{ inputs.ref_name }}-${GITHUB_SHA::8}" >> $GITHUB_ENV
 
             -   name: Set TAG_NAME
                 if: ${{ ! inputs.tag_add_commithash }}


### PR DESCRIPTION
Bei deployment von einem Branch funktioniert das deployment nicht, da sich der Name vom Image nicht ändert.
Bei Mitgabe der Flag `tag_add_commithash` wird das image mit `-<commit-ish>` postfixxed.