### PR TITLE
focal image as default not required anymore

### DIFF
--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -172,7 +172,7 @@ jobs:
             -   name: Set default docker image
                 if: "${{ ! inputs.jib_custom_docker_image }}"
                 run: |
-                    echo "DOCKER_IMAGE=eclipse-temurin:${{ inputs.java_version }}-focal" >> $GITHUB_ENV
+                    echo "DOCKER_IMAGE=eclipse-temurin:${{ inputs.java_version }}" >> $GITHUB_ENV
 
             -   name: jib_custom_docker_image_repo to env variable for use in if check
                 run: |


### PR DESCRIPTION
 as no more images are build for targets which had an issue with newer images (RegaDA on the old CentOS VMs)