### PR TITLE
Allow optional java_opts

### DIFF
--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -204,4 +204,4 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
-                    -Djib.container.entrypoint='java,$ADDITIONAL_JAVA_OPTS,-XX:MinRAMPercentage=60.0,-XX:MaxRAMPercentage=80.0,-cp,$( cat /app/jib-classpath-file),$( cat /app/jib-main-class-file )' 
+                    -Djib.container.entrypoint='sh,-c,"java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp $( cat /app/jib-classpath-file) $( cat /app/jib-main-class-file )"' 

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -205,4 +205,4 @@ jobs:
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
                     -Djib.containerizingMode='packaged' \
-                    -Djib.container.entrypoint='sh,-c,"java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file $( cat /app/jib-main-class-file )"' 
+                    -Djib.container.entrypoint='sh,-c,java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file @/app/jib-main-class-file' 

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -204,4 +204,4 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
-                    -Djib.container.jvmFlags=-XX:MinRAMPercentage=60.0,-XX:MaxRAMPercentage=80.0
+                    -Djib.container.entrypoint="java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file @/app/jib-main-class-file"

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -204,5 +204,4 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
-                    -Djib.containerizingMode='packaged' \
                     -Djib.container.entrypoint='sh,-c,java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file @/app/jib-main-class-file' 

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -204,4 +204,4 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
-                    -Djib.container.entrypoint='java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp $( cat /app/jib-classpath-file) $( cat /app/jib-main-class-file )' 
+                    -Djib.container.entrypoint='java,$ADDITIONAL_JAVA_OPTS,-XX:MinRAMPercentage=60.0,-XX:MaxRAMPercentage=80.0,-cp,$( cat /app/jib-classpath-file),$( cat /app/jib-main-class-file )' 

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -204,4 +204,5 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
+                    -Djib.containerizingMode='packaged' \
                     -Djib.container.entrypoint='sh,-c,"java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp $( cat /app/jib-classpath-file) $( cat /app/jib-main-class-file )"' 

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -204,4 +204,4 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
-                    -Djib.container.entrypoint='java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file @/app/jib-main-class-file'
+                    -Djib.container.entrypoint='java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp $( cat /app/jib-classpath-file) $( cat /app/jib-main-class-file )' 

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -205,4 +205,4 @@ jobs:
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
                     -Djib.containerizingMode='packaged' \
-                    -Djib.container.entrypoint='sh,-c,"java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp $( cat /app/jib-classpath-file) $( cat /app/jib-main-class-file )"' 
+                    -Djib.container.entrypoint='sh,-c,"java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file $( cat /app/jib-main-class-file )"' 

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -204,4 +204,4 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
-                    -Djib.container.entrypoint="java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file @/app/jib-main-class-file"
+                    -Djib.container.entrypoint='java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file @/app/jib-main-class-file'


### PR DESCRIPTION
Sometimes we need the ability to add jvmFlags at Runtime. As jib does not offer this directly, we need to overwrite the entrypoint.

This should not be a breaking change, as the startup command should be identical to before.