### PR TITLE
Update mvn_docker_image.yml

### DIFF
--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -207,4 +207,4 @@ jobs:
                     -Djib.to.auth.password=${{ secrets.acr_password }} \
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SPRING_CONFIG_LOCATION="/config/" \
-                    -Djib.container.entrypoint='sh,-c,java $ADDITIONAL_JAVA_OPTS -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -cp @/app/jib-classpath-file @/app/jib-main-class-file $@' 
+                    -Djib.container.entrypoint='sh,-c,java -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 $ADDITIONAL_JAVA_OPTS -cp @/app/jib-classpath-file @/app/jib-main-class-file $@' 


### PR DESCRIPTION
JVM seems to always use the last argument, by moving the env var we allow a deployment to override our default values.