### PR TITLE
Add tag to build

### DIFF
--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -108,7 +108,7 @@ jobs:
 
             -   name: Build using yarn
                 run: |
-                    cd ${{ inputs.app_directory }} && REACT_APP_VERSION_STRING=${{ github.event.inputs.tag }} yarn run build${{ inputs.build_cmd_postfix }}:${{ inputs.release_env }}
+                    cd ${{ inputs.app_directory }} && REACT_APP_VERSION_STRING=${{ inputs.ref_name }} yarn run build${{ inputs.build_cmd_postfix }}:${{ inputs.release_env }}
 
             -   name: Tar Build dir to docker
                 run: |

--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -108,7 +108,7 @@ jobs:
 
             -   name: Build using yarn
                 run: |
-                    cd ${{ inputs.app_directory }} && yarn run build${{ inputs.build_cmd_postfix }}:${{ inputs.release_env }}
+                    cd ${{ inputs.app_directory }} && REACT_APP_VERSION_STRING=${{ github.event.inputs.tag }} yarn run build${{ inputs.build_cmd_postfix }}:${{ inputs.release_env }}
 
             -   name: Tar Build dir to docker
                 run: |

--- a/.github/workflows/yarn_install.yml
+++ b/.github/workflows/yarn_install.yml
@@ -54,7 +54,7 @@ jobs:
             -   name: Build for Environment
                 if: ${{ inputs.release_env }}
                 run: |
-                    cd ${{ inputs.app_directory }} && CI=${{ inputs.yarn_ci_flag }} yarn build:${{ inputs.release_env }}
+                    cd ${{ inputs.app_directory }} && CI=${{ inputs.yarn_ci_flag }} REACT_APP_VERSION_STRING=${{ github.event.inputs.tag }} yarn build:${{ inputs.release_env }}
             -   uses: actions/upload-artifact@v3
                 if: ${{ inputs.release_env }}
                 with:

--- a/.github/workflows/yarn_install.yml
+++ b/.github/workflows/yarn_install.yml
@@ -54,7 +54,7 @@ jobs:
             -   name: Build for Environment
                 if: ${{ inputs.release_env }}
                 run: |
-                    cd ${{ inputs.app_directory }} && CI=${{ inputs.yarn_ci_flag }} REACT_APP_VERSION_STRING=${{ github.event.inputs.tag }} yarn build:${{ inputs.release_env }}
+                    cd ${{ inputs.app_directory }} && CI=${{ inputs.yarn_ci_flag }} REACT_APP_VERSION_STRING=${{ inputs.ref_name }} yarn build:${{ inputs.release_env }}
             -   uses: actions/upload-artifact@v3
                 if: ${{ inputs.release_env }}
                 with:


### PR DESCRIPTION
Wir brauchen das bei RegaGB. Kann man aber wohl grundsätzlich bei jedem Build gebrauchen, falls man mal irgendwo im UI die aktuell deployte Version anzeigen muss.

Frage wäre wohl noch: gibt es eine sinnvolleren Variablen-Namen als: `REACT_APP_VERSION_STRING `
Oder hat der Prefix: `REACT_APP` irgendeinen Grund?