### PR TITLE
remove `tar_directory`

### DIFF
--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -112,7 +112,7 @@ jobs:
 
             -   name: Tar Build dir to docker
                 run: |
-                    tar -czvf docker/${{ inputs.app_name }}/bin/${{ inputs.app_name }}.tar.gz -C ${{ inputs.app_directory }}/${{ inputs.dirs_for_docker_build }}
+                    tar -czvf docker/${{ inputs.app_name }}/bin/${{ inputs.app_name }}.tar.gz -C ${{ inputs.app_directory }} ${{ inputs.dirs_for_docker_build }}
 
             -   name: Set TAG_NAME with commit hash
                 if: ${{ inputs.tag_add_commithash }}

--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -49,12 +49,7 @@ on:
             dirs_for_docker_build:
                 required: true
                 type: string
-                description: Space-separated list of files or glob pattern to include in docker build context. E.g. 'public .next' for .next builds or '.' for other web builds.
-            tar_directory:
-                required: false
-                default: ""
-                type: string
-                description: Change to this directory before packaging files as tar.gz. For regular web builds this would usually be 'build'
+                description: Space-separated list of files or glob pattern to include in docker build context. E.g. 'public .next' for .next builds or 'build' for other web builds.
 
         secrets:
             acr_registry:
@@ -117,7 +112,7 @@ jobs:
 
             -   name: Tar Build dir to docker
                 run: |
-                    tar -czvf docker/${{ inputs.app_name }}/bin/${{ inputs.app_name }}.tar.gz -C ${{ inputs.app_directory }}/${{ inputs.tar_directory}} ${{ inputs.dirs_for_docker_build }}
+                    tar -czvf docker/${{ inputs.app_name }}/bin/${{ inputs.app_name }}.tar.gz -C ${{ inputs.app_directory }}/${{ inputs.dirs_for_docker_build }}
 
             -   name: Set TAG_NAME with commit hash
                 if: ${{ inputs.tag_add_commithash }}


### PR DESCRIPTION
Use new docker image (same as regada, rega, uzh) that eliminates the need for `tar_directory`