### PR TITLE
explicitly set ref for actions/checkout

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -67,6 +67,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
                 with:
+                    ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
             -   name: Login to Azure CR

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -3,8 +3,7 @@ on:
     workflow_call:
         inputs:
             ref_name:
-                required: false
-                default: ''
+                required: true
                 type: string
                 description: tag or branch name, used for mvn versions:set
             checkout_lfs:

--- a/.github/workflows/k8s_deploy.yml
+++ b/.github/workflows/k8s_deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy on Kubernetes Cluster
 on:
     workflow_call:
-
         inputs:
             ref_name:
                 required: true

--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -1,7 +1,6 @@
 name: Build with maven and Push to Docker Registry
 on:
     workflow_call:
-
         inputs:
             ref_name:
                 required: true

--- a/.github/workflows/mvn_github_release.yml
+++ b/.github/workflows/mvn_github_release.yml
@@ -3,8 +3,7 @@ on:
     workflow_call:
         inputs:
             ref_name:
-                required: false
-                default: ''
+                required: true
                 type: string
                 description: tag or branch name, used for mvn versions:set
             checkout_lfs:

--- a/.github/workflows/mvn_github_release.yml
+++ b/.github/workflows/mvn_github_release.yml
@@ -49,6 +49,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
                 with:
+                    ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
             -   name: Set up JDK

--- a/.github/workflows/mvn_install.yml
+++ b/.github/workflows/mvn_install.yml
@@ -52,6 +52,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
                 with:
+                    ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
             -   name: Set up JDK

--- a/.github/workflows/mvn_install.yml
+++ b/.github/workflows/mvn_install.yml
@@ -1,7 +1,6 @@
 name: Runs Maven Install
 on:
     workflow_call:
-
         inputs:
             ref_name:
                 required: false

--- a/.github/workflows/mvn_install.yml
+++ b/.github/workflows/mvn_install.yml
@@ -3,8 +3,7 @@ on:
     workflow_call:
         inputs:
             ref_name:
-                required: false
-                default: ''
+                required: true
                 type: string
                 description: tag or branch name, used for mvn versions:set
             checkout_lfs:

--- a/.github/workflows/mvn_package_deploy.yml
+++ b/.github/workflows/mvn_package_deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy Maven Package
 on:
     workflow_call:
-
         inputs:
             parent_pom:
                 required: true

--- a/.github/workflows/mvn_package_deploy.yml
+++ b/.github/workflows/mvn_package_deploy.yml
@@ -5,10 +5,10 @@ on:
             parent_pom:
                 required: true
                 type: string
-                description: tag or branch name, used for mvn versions:set
             ref_name:
-                type: string
                 required: true
+                type: string
+                description: tag or branch name, used for mvn versions:set
             java_version:
                 default: '21'
                 type: string

--- a/.github/workflows/mvn_package_deploy.yml
+++ b/.github/workflows/mvn_package_deploy.yml
@@ -45,6 +45,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
                 with:
+                    ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
             -   name: Set up JDK

--- a/.github/workflows/mvn_verify_sonar.yml
+++ b/.github/workflows/mvn_verify_sonar.yml
@@ -54,6 +54,7 @@ jobs:
             -   uses: actions/checkout@v4
                 with:
                     fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+                    ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
             -   name: Set up JDK

--- a/.github/workflows/mvn_verify_sonar.yml
+++ b/.github/workflows/mvn_verify_sonar.yml
@@ -1,7 +1,6 @@
 name: Run Sonar Cloud Analysis with Maven Verify
 on:
     workflow_call:
-
         inputs:
             parent_pom:
                 required: true

--- a/.github/workflows/pnpm_docker_image.yml
+++ b/.github/workflows/pnpm_docker_image.yml
@@ -1,7 +1,6 @@
 name: Build and Push Docker Images on release/
 on:
     workflow_call:
-
         inputs:
             ref_name:
                 required: true

--- a/.github/workflows/pnpm_docker_image.yml
+++ b/.github/workflows/pnpm_docker_image.yml
@@ -123,6 +123,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
                 with:
+                    ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
             -   uses: pnpm/action-setup@v2

--- a/.github/workflows/pnpm_install.yml
+++ b/.github/workflows/pnpm_install.yml
@@ -3,8 +3,7 @@ on:
     workflow_call:
         inputs:
             ref_name:
-                required: false
-                default: ''
+                required: true
                 type: string
                 description: tag or branch name for checkout
             node_version:

--- a/.github/workflows/sentry_release.yml
+++ b/.github/workflows/sentry_release.yml
@@ -1,7 +1,6 @@
 name: Sentry Release
 on:
     workflow_call:
-
         inputs:
             ref_name:
                 required: true

--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -1,7 +1,6 @@
 name: Build and Push Docker Images on release/
 on:
     workflow_call:
-
         inputs:
             ref_name:
                 required: true

--- a/.github/workflows/yarn_docker_image.yml
+++ b/.github/workflows/yarn_docker_image.yml
@@ -100,6 +100,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
                 with:
+                    ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
             -   name: Install yarn without node

--- a/.github/workflows/yarn_install.yml
+++ b/.github/workflows/yarn_install.yml
@@ -3,8 +3,7 @@ on:
     workflow_call:
         inputs:
             ref_name:
-                required: false
-                default: ''
+                required: true
                 type: string
                 description: tag or branch name for checkout
             node_version:

--- a/.github/workflows/yarn_install.yml
+++ b/.github/workflows/yarn_install.yml
@@ -1,7 +1,6 @@
 name: Runs Yarn Install
 on:
     workflow_call:
-
         inputs:
             ref_name:
                 required: false


### PR DESCRIPTION
This should already always be what happens in all our use-cases, according to the doku of https://github.com/actions/checkout#usage:

<img width="652" alt="image" src="https://github.com/UbiqueInnovation/workflows-backend/assets/18676949/efd9db64-e074-4ac4-b303-dd119c10941c">

But, making it explicit is surely better for cases where we need to make sure the correct version of the code is checked-out.

Some of the workflows already had this set, Let's make sure the behaviour is the same for all workflows
