### PR TITLE
performing mvn versions:set is absolutely not required and in mvn_ins…

### DIFF
--- a/.github/workflows/mvn_install.yml
+++ b/.github/workflows/mvn_install.yml
@@ -5,7 +5,7 @@ on:
             ref_name:
                 required: true
                 type: string
-                description: tag or branch name, used for mvn versions:set
+                description: tag or branch name to checkout
             checkout_lfs:
                 required: false
                 default: false
@@ -80,21 +80,6 @@ jobs:
                 with:
                     servers: '[{"id": "ubique-artifactory", "username": "${{ secrets.artifactory_user}}", "password": "${{ secrets.artifactory_password }}"}]'
                     repositories: '[{"id" : "ubique-artifactory", "url" : "${{ secrets.artifactory_url }}${{ secrets.artifactory_repo }}"}]'
-
-            -   name: Set VERSION from ref_name
-                run: echo "VERSION=${{ inputs.ref_name }}" >> $GITHUB_ENV
-
-            -   name: Replace all characters in `\/:"<>|?*` by `-` in VERSION
-                run: echo "VERSION=$(echo "$VERSION" | sed 's/[\/:"<>|?*]/-/g')" >> $GITHUB_ENV
-
-            -   name: Strip leading `v` from VERSION
-                run: echo "VERSION=${VERSION##v}" >> $GITHUB_ENV
-
-            -   name: Set versions
-                run: mvn -f ${{ inputs.parent_pom }} versions:set -DnewVersion=$VERSION
-
-            -   name: Commit versions
-                run: mvn -f ${{ inputs.parent_pom }} versions:commit
 
             -   name: Build with Maven
                 run: mvn --batch-mode --update-snapshots install -DskipTests=${{ inputs.skip_tests }} -f ${{ inputs.parent_pom }}


### PR DESCRIPTION
…tall workflow and now breaks if you build from a branch and not a tag

Fixes broken mvn_install, see:

broken in: https://github.com/UbiqueInnovation/backend-jvm-lib/actions/runs/9809968199
fixed in: https://github.com/UbiqueInnovation/backend-jvm-lib/actions/runs/9810810705/job/27091764227