### PR TITLE
remove step sentry_release from mvn_docker_image.yml, as it fails qui…

### DIFF
--- a/.github/workflows/mvn_docker_image.yml
+++ b/.github/workflows/mvn_docker_image.yml
@@ -100,11 +100,6 @@ on:
                 required: false
                 type: string
                 description: only applicable if runs_on self_hosted
-            create_sentry_release:
-                required: false
-                default: false
-                type: boolean
-                description: if enabled, a sentry release is created
 
         secrets:
             artifactory_user:
@@ -147,15 +142,6 @@ on:
             self_hosted_cache_secret_key:
                 required: false
                 description: required if runs_on self_hosted
-            sentry_auth_token:
-                required: false
-                description: required if create_sentry_release is true
-            sentry_org:
-                required: false
-                description: required if create_sentry_release is true
-            sentry_project:
-                required: false
-                description: required if create_sentry_release is true
 
 jobs:
     create-docker-image:
@@ -362,15 +348,3 @@ jobs:
                     -Djib.container.volumes=${{ inputs.jib_container_volumes }} \
                     -Djib.container.environment=VERSION_TAG_NAME="${{ env.TAG_NAME }}",SENTRY_RELEASE="${{ env.VERSION }}",SPRING_CONFIG_LOCATION="/config/",SPRING_DOCKER_COMPOSE_ENABLED=false \
                     -Djib.container.entrypoint='sh,-c,java -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 $ADDITIONAL_JAVA_OPTS -cp @/app/jib-classpath-file @/app/jib-main-class-file $@'
-
-            -   name: Create Sentry release
-                uses: getsentry/action-release@ccab2088f17098afc92fc485a69b8371b393c476
-                if: ${{ inputs.create_sentry_release }}
-                env:
-                    SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
-                    SENTRY_ORG: ${{ secrets.sentry_org }}
-                    SENTRY_PROJECT: ${{ secrets.sentry_project }}
-                with:
-                    version: ${{ env.VERSION }}
-                    ignore_missing: true
-                    ignore_empty: true

--- a/.github/workflows/sentry_release.yml
+++ b/.github/workflows/sentry_release.yml
@@ -37,6 +37,15 @@ jobs:
                     ref: ${{ inputs.ref_name }}
                     lfs: ${{ inputs.checkout_lfs }}
 
+            -   name: Set VERSION from ref_name
+                run: echo "VERSION=${{ inputs.ref_name }}" >> $GITHUB_ENV
+
+            -   name: Replace all characters in `\/:"<>|?*` by `-` in VERSION
+                run: echo "VERSION=$(echo "$VERSION" | sed 's/[\/:"<>|?*]/-/g')" >> $GITHUB_ENV
+
+            -   name: Strip leading `v` from VERSION
+                run: echo "VERSION=${VERSION##v}" >> $GITHUB_ENV
+
             -   name: Create Sentry release
                 uses: getsentry/action-release@ccab2088f17098afc92fc485a69b8371b393c476
                 env:
@@ -45,5 +54,7 @@ jobs:
                     SENTRY_PROJECT: ${{ secrets.sentry_project }}
                 with:
                     environment: ${{ inputs.target }}
-                    version: ${{ inputs.ref_name }}
+                    version: ${{ env.VERSION }}
                     finalize: ${{ inputs.finalize }}
+                    ignore_missing: true
+                    ignore_empty: true

--- a/.github/workflows/sentry_release.yml
+++ b/.github/workflows/sentry_release.yml
@@ -7,7 +7,7 @@ on:
                 type: string
                 description: tag or branch name
             target:
-                required: true
+                required: false
                 type: string
                 description: dev|int|prod|etc.
             checkout_lfs:


### PR DESCRIPTION
…te consistently on parallel execution

Use dedicated sentry_release.yml workflow, with the version no being consistent with mvn_docker_image.yml

See https://github.com/UbiqueInnovation/ubmeteo-backend/actions/runs/10421370569 and https://github.com/UbiqueInnovation/ubmeteo-backend/actions/runs/10421409017