### PR TITLE
use name instead of tag_name

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -62,7 +62,7 @@ jobs:
             -   name: Create new release
                 uses: softprops/action-gh-release@e5aff6f50fb1cde6005b4a5d0ac851e076e3bd7a
                 with:
-                    tag_name: ${{ env.TAG_NAME }}
+                    name: ${{ env.TAG_NAME }}
                     body: ${{ env.RELEASE_BODY }}
                     token: ${{ secrets.repo_token }}
                     prerelease: ${{ inputs.release_option_prerelease }}

--- a/.github/workflows/mvn_github_release.yml
+++ b/.github/workflows/mvn_github_release.yml
@@ -95,6 +95,7 @@ jobs:
             -   name: Create new release
                 uses: softprops/action-gh-release@e5aff6f50fb1cde6005b4a5d0ac851e076e3bd7a
                 with:
+                    name: ${{ env.VERSION }}
                     token: ${{ secrets.repo_token }}
                     prerelease: ${{ inputs.release_option_prerelease }}
                     files: ${{ inputs.release_option_files }}


### PR DESCRIPTION
Previously, this created a tag named ${{ env.TAG_NAME }} on the default branch. We do not want to create a new tag, we just want to set the name of the release to be ${{ env.TAG_NAME }}