### PR TITLE
maven package deploy: add -DaltDeploymentRepository

### DIFF
--- a/.github/workflows/mvn_package_deploy.yml
+++ b/.github/workflows/mvn_package_deploy.yml
@@ -98,4 +98,4 @@ jobs:
                 run: mvn -f ${{ inputs.parent_pom }} versions:commit
 
             -   name: Deploy package
-                run: mvn -f ${{ inputs.parent_pom }} deploy -DskipTests
+                run: mvn -f ${{ inputs.parent_pom }} deploy -DskipTests -DaltDeploymentRepository="ubique-artifactory::${{ secrets.artifactory_url }}${{ secrets.artifactory_repo }}"


### PR DESCRIPTION
Add [-DaltDeploymentRepository](https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#altDeploymentRepository) pointing to the (secret) repo URL to the maven deploy command. This obviates the need to add the distributionManagement clause in the project POM, with the repo URL in plain-text.

Enabled unconditionally; AFAIU, this workflow cannot be used to push to any other repo anyway (and setting `use_mvn_central` will very likely fail?).