### PR TITLE
make docker cache optional

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -48,6 +48,11 @@ on:
                 required: false
                 type: string
                 description: required if input container_registry_type is 'amazon-ecr'
+            use_cache:
+                required: false
+                default: true
+                type: boolean
+                description: Whether to use GitHub Actions cache for Docker builds
 
         secrets:
             acr_registry:
@@ -121,6 +126,6 @@ jobs:
                     labels: ${{ steps.docker_meta.outputs.labels }}
                     push: true
                     context: ${{ inputs.context }}
-                    cache-from: type=gha
-                    cache-to: type=gha,mode=max
+                    cache-from: ${{ inputs.use_cache && 'type=gha' || '' }}
+                    cache-to: ${{ inputs.use_cache && 'type=gha,mode=max' || '' }}
                     build-args: ${{ inputs.build_args }}


### PR DESCRIPTION
Bei App Insights laden wir ein ML Model ins Docker image. Diese wird dadurch sehr gross was zu Problemen beim Caching führt (https://github.com/docker/build-push-action/issues/252). Darum wäre es gut wenn man das (zumindest als workaround) disablen könnte.