### PR TITLE
mvn install/github release: restore cache without matching pom hash

### DIFF
--- a/.github/workflows/mvn_github_release.yml
+++ b/.github/workflows/mvn_github_release.yml
@@ -68,6 +68,8 @@ jobs:
                 with:
                     path: ~/.m2/repository
                     key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+                    restore-keys: |
+                      ${{ runner.os }}-m2-
 
             -   name: Create maven central settings.xml
                 if: ${{ inputs.use_mvn_central }}

--- a/.github/workflows/mvn_install.yml
+++ b/.github/workflows/mvn_install.yml
@@ -70,6 +70,8 @@ jobs:
                 with:
                     path: ~/.m2/repository
                     key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+                    restore-keys: |
+                      ${{ runner.os }}-m2-
 
             -   name: install apt packages '${{ inputs.install_apt_packages }}'
                 if: ${{ inputs.install_apt_packages }}


### PR DESCRIPTION
Allow restoring cache without matching pom.xml hash, so that builds dont have to download everything fresh on every change to the pom files. This is already enabled in most maven workflows, this change only adds it to mvn_install and mvn_github_release, where it was missing.